### PR TITLE
Update SecureCmdClassRestrictions function

### DIFF
--- a/Lib/SecureCmd.lua
+++ b/Lib/SecureCmd.lua
@@ -349,12 +349,12 @@ local function SecureCmdClassRestrictions( options )
                 pethappy = {"HUNTER"},
                 petloyalty = {"HUNTER"},
                 shadowform = {"PRIEST"},
-                stealth = {"ROGUE"},
+                stealth = {"DRUID", "ROGUE"},
         }
         
         local o = SCO_Restrictions[options] 
         if o then
-                if not ME_CheckResultsFromTable(UnitClass("player"),o) then
+                if not ME_CheckResultsFromTable(Select(2,UnitClass("player")),o) then
                         return nil
                 end
         end


### PR DESCRIPTION
Fixes class restrictions:
    - 'UnitClass("player")' returns capitalized string (i.e. "Druid"). Rest of the code uses 'Select(2,UnitClass("player"))' for class comparison which returns uppercase (i.e. "DRUID")

Fixes "stealth" condition for druid:
    - Druid class was restricted from stealth keyword - added to list.